### PR TITLE
Various Fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,4 +31,4 @@ Suggests:
 LazyData: yes
 ByteCompile: yes
 LinkingTo: Rcpp, RcppArmadillo
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.1

--- a/R/addCountingWrapper.R
+++ b/R/addCountingWrapper.R
@@ -11,7 +11,7 @@
 #'   Smoof function which should be wrapped.
 #' @return [\code{smoof_counting_function}]
 #' @examples
-#' fn = makeBBOBFunction(dimension = 2L, fid = 1L, iid = 1L)
+#' fn = makeBBOBFunction(dimensions = 2L, fid = 1L, iid = 1L)
 #' fn = addCountingWrapper(fn)
 #'
 #' # we get a value of 0 since the function has not been called yet

--- a/R/addLoggingWrapper.R
+++ b/R/addLoggingWrapper.R
@@ -17,7 +17,7 @@
 #' @return [\code{smoof_logging_function}]
 #' @examples
 #' # We first build the smoof function and apply the logging wrapper to it
-#' fn = makeSphereFunction(dimension = 2L)
+#' fn = makeSphereFunction(dimensions = 2L)
 #' fn = addLoggingWrapper(fn, logg.x = TRUE)
 #'
 #' # We now apply an optimization algorithm to it and the logging wrapper keeps

--- a/R/makeBBOBFunction.R
+++ b/R/makeBBOBFunction.R
@@ -5,7 +5,7 @@
 #' It is possible to pass a matrix of parameters to the functions, where
 #' each column consists of one parameter setting.
 #'
-#' @param dimension [\code{integer(1)}]\cr
+#' @param dimensions [\code{integer(1)}]\cr
 #'   Problem dimension. Integer value between 2 and 40.
 #' @param fid [\code{integer(1)}]\cr
 #'   Function identifier. Integer value between 1 and 24.
@@ -14,42 +14,42 @@
 #' @return [\code{smoof_single_objective_function}]
 #' @examples
 #' # get the first instance of the 2D Sphere function
-#' fn = makeBBOBFunction(dimension = 2L, fid = 1L, iid = 1L)
+#' fn = makeBBOBFunction(dimensions = 2L, fid = 1L, iid = 1L)
 #' if (require(plot3D)) {
 #'   plot3D(fn, contour = TRUE)
 #' }
 #' @references See the \href{http://coco.gforge.inria.fr/doku.php?id=bbob-2009-downloads}{BBOB website}
 #' for a detailed description of the BBOB functions.
 #' @export
-makeBBOBFunction = function(dimension, fid, iid) {
+makeBBOBFunction = function(dimensions, fid, iid) {
   # do some sanity checks
-  dimension = asCount(dimension)
+  dimensions = asCount(dimensions)
   fid = asCount(fid)
   iid = asCount(iid)
-  assertInt(dimension, lower = 2L, upper = 40L)
+  assertInt(dimensions, lower = 2L, upper = 40L)
   assertInt(fid, lower = 1L, upper = 24L)
   assertInt(iid, lower = 1L)
 
   # touch vars
-  force(dimension)
+  force(dimensions)
   force(fid)
   force(iid)
 
   # build parameter set (bounds are [-5, 5] for all BBOB funs)
-  par.set = makeNumericParamSet("x", len = dimension, lower = -5, upper = 5)
+  par.set = makeNumericParamSet("x", len = dimensions, lower = -5, upper = 5)
 
   # get optimal values
-  optimals = getOptimumForBBOBFunction(dimension, fid, iid)
+  optimals = getOptimumForBBOBFunction(dimensions, fid, iid)
 
   # get metadata, i. e., tags and name
   meta = mapBBOBFidToMetaData(fid)
 
   makeSingleObjectiveFunction(
-    name = sprintf("BBOB_%i_%i_%i", dimension, fid, iid),
+    name = sprintf("BBOB_%i_%i_%i", dimensions, fid, iid),
     description = sprintf("%i-th noiseless BBOB function\n(FID: %i, IID: %i, DIMENSION: %i)",
-      fid, fid, iid, dimension),
+      fid, fid, iid, dimensions),
     fn = function(x) {
-      .Call("evaluateBBOBFunctionCPP", dimension, fid, iid, x)
+      .Call("evaluateBBOBFunctionCPP", dimensions, fid, iid, x)
     },
     par.set = par.set,
     tags = meta$tags,
@@ -96,6 +96,6 @@ mapBBOBFidToMetaData = function(fid) {
 
 # Get the optimal parameter values and the optimal function value for a BBOB
 # function.
-getOptimumForBBOBFunction = function(dimension, fid, iid) {
-  .Call("getOptimumForBBOBFunctionCPP", dimension, fid, iid)
+getOptimumForBBOBFunction = function(dimensions, fid, iid) {
+  .Call("getOptimumForBBOBFunctionCPP", dimensions, fid, iid)
 }

--- a/R/makeBiObjBBOBFunction.R
+++ b/R/makeBiObjBBOBFunction.R
@@ -5,8 +5,8 @@
 #' Concatenation of single-objective BBOB functions into
 #' a bi-objective problem.
 #'
-#' @param dimension [\code{integer(1)}]\cr
-#'   Problem dimension. Integer value between 2 and 40.
+#' @param dimensions [\code{integer(1)}]\cr
+#'   Problem dimensions. Integer value between 2 and 40.
 #' @param fid [\code{integer(1)}]\cr
 #'   Function identifier. Integer value between 1 and 55.
 #' @param iid [\code{integer(1)}]\cr
@@ -15,28 +15,28 @@
 #' @examples
 #' # get the fifth instance of the concatenation of the
 #' # 3D versions of sphere and Rosenbrock
-#' fn = makeBiObjBBOBFunction(dimension = 3L, fid = 4L, iid = 5L)
+#' fn = makeBiObjBBOBFunction(dimensions = 3L, fid = 4L, iid = 5L)
 #' fn(c(3, -1, 0))
 #' # compare to the output of its single-objective pendants
-#' f1 = makeBBOBFunction(dimension = 3L, fid = 1L, iid = 2L * 5L + 1L)
-#' f2 = makeBBOBFunction(dimension = 3L, fid = 8L, iid = 2L * 5L + 2L)
+#' f1 = makeBBOBFunction(dimensions = 3L, fid = 1L, iid = 2L * 5L + 1L)
+#' f2 = makeBBOBFunction(dimensions = 3L, fid = 8L, iid = 2L * 5L + 2L)
 #' identical(fn(c(3, -1, 0)), c(f1(c(3, -1, 0)), f2(c(3, -1, 0))))
 #' @references See the \href{http://numbbo.github.io/coco-doc/bbob-biobj/functions/}{COCO website}
 #' for a detailed description of the bi-objective BBOB functions.
 #' An overview of which pair of single-objective BBOB functions creates
 #' which of the 55 bi-objective BBOB functions can be found \href{http://numbbo.github.io/coco-doc/bbob-biobj/functions/#the-bbob-biobj-test-functions-and-their-properties}{here}.
 #' @export
-makeBiObjBBOBFunction = function(dimension, fid, iid) {
+makeBiObjBBOBFunction = function(dimensions, fid, iid) {
   # do some sanity checks
-  dimension = asCount(dimension)
+  dimensions = asCount(dimensions)
   fid = asCount(fid)
   iid = asCount(iid)
-  assertInt(dimension, lower = 2L, upper = 40L)
+  assertInt(dimensions, lower = 2L, upper = 40L)
   assertInt(fid, lower = 1L, upper = 55L)
   assertInt(iid, lower = 1L)
 
   # touch vars
-  force(dimension)
+  force(dimensions)
   force(fid)
   force(iid)
 
@@ -58,16 +58,16 @@ makeBiObjBBOBFunction = function(dimension, fid, iid) {
   iid2 = iid1 + 1L
 
   # build parameter set (bounds are [-5, 5] for all BBOB funs)
-  par.set = makeNumericParamSet("x", len = dimension, lower = -5, upper = 5)
+  par.set = makeNumericParamSet("x", len = dimensions, lower = -5, upper = 5)
 
   makeMultiObjectiveFunction(
-    name = sprintf("Bi-Objective BBOB_%i_%i_%i", dimension, fid, iid),
-    id = paste0("biobj_bbob_", dimension, "d_2o"),
+    name = sprintf("Bi-Objective BBOB_%i_%i_%i", dimensions, fid, iid),
+    id = paste0("biobj_bbob_", dimensions, "d_2o"),
     description = sprintf("%i-th noiseless Bi-Objective BBOB function\n(FID: %i, IID: %i, DIMENSION: %i)",
-      fid, fid, iid, dimension),
+      fid, fid, iid, dimensions),
     fn = function(x) {
-      c(.Call("evaluateBBOBFunctionCPP", dimension, fid1, iid1, x),
-        .Call("evaluateBBOBFunctionCPP", dimension, fid2, iid2, x))
+      c(.Call("evaluateBBOBFunctionCPP", dimensions, fid1, iid1, x),
+        .Call("evaluateBBOBFunctionCPP", dimensions, fid2, iid2, x))
     },
     par.set = par.set,
     n.objectives = 2L,

--- a/R/makeUFFunction.R
+++ b/R/makeUFFunction.R
@@ -51,7 +51,7 @@ attr(makeUFFunction, "type") = c("Multi-objective")
 #
 # @param id [integer(1)]
 #   UF function id.
-# @param dimension [integer(1)]
+# @param dimensions [integer(1)]
 #   Problem space dimension.
 # @return [ParamSet]
 makeUFParamSet = function(id, dimensions) {

--- a/R/mof.zdt1.R
+++ b/R/mof.zdt1.R
@@ -19,7 +19,7 @@
 #' @return [\code{smoof_multi_objective_function}]
 #' @export
 makeZDT1Function = function(dimensions) {
-  assertNumber(dimensions, lower = 2L)
+  assertInt(dimensions, lower = 2L)
   force(dimensions)
 
   # define the two-objective ZDT1 function

--- a/R/mof.zdt2.R
+++ b/R/mof.zdt2.R
@@ -20,7 +20,7 @@
 #' @return [\code{smoof_multi_objective_function}]
 #' @export
 makeZDT2Function = function(dimensions) {
-  assertNumber(dimensions, lower = 2L)
+  assertInt(dimensions, lower = 2L)
   force(dimensions)
 
     # define the two-objective ZDT1 function

--- a/R/mof.zdt3.R
+++ b/R/mof.zdt3.R
@@ -22,7 +22,7 @@
 #' @return [\code{smoof_multi_objective_function}]
 #' @export
 makeZDT3Function = function(dimensions) {
-  assertNumber(dimensions, lower = 2L)
+  assertInt(dimensions, lower = 2L)
   force(dimensions)
 
     # define the two-objective ZDT1 function

--- a/R/mof.zdt4.R
+++ b/R/mof.zdt4.R
@@ -21,7 +21,7 @@
 #' @return [\code{smoof_multi_objective_function}]
 #' @export
 makeZDT4Function = function(dimensions) {
-  assertNumber(dimensions, lower = 2L)
+  assertInt(dimensions, lower = 2L)
   force(dimensions)
 
   # define the two-objective ZDT1 function

--- a/R/mof.zdt6.R
+++ b/R/mof.zdt6.R
@@ -22,7 +22,7 @@
 #' @return [\code{smoof_multi_objective_function}]
 #' @export
 makeZDT6Function = function(dimensions) {
-  assertNumber(dimensions, lower = 2L)
+  assertInt(dimensions, lower = 2L)
   force(dimensions)
 
     # define the two-objective ZDT1 function

--- a/R/plot.autoplot.R
+++ b/R/plot.autoplot.R
@@ -145,7 +145,7 @@ autoplot.smoof_function = function(x,
       # see http://learnr.wordpress.com/2009/07/20/ggplot2-version-of-figures-in-lattice-multivariate-data-visualization-with-r-part-6/
       brewer.div = colorRampPalette(brewer.pal(11, "Spectral"), interpolate = "spline")
 
-      pl = pl + geom_tile(aes_string(fill = "y"))
+      pl = pl + geom_raster(aes_string(fill = "y"))
       pl = pl + scale_fill_gradientn(colours = brewer.div(200))
     }
     if (render.contours) {

--- a/R/sof.mpm2.R
+++ b/R/sof.mpm2.R
@@ -89,7 +89,7 @@ makeMPM2Function = function(n.peaks, dimensions, topology, seed, rotated = TRUE,
 }
 
 class(makeMPM2Function) = c("function", "smoof_generator")
-attr(makeMPM2Function, "name") = c("Multiple peals model 2 function generator")
+attr(makeMPM2Function, "name") = c("Multiple peaks model 2 function generator")
 attr(makeMPM2Function, "type") = c("single-objective")
 
 

--- a/R/sof.rosenbrock.R
+++ b/R/sof.rosenbrock.R
@@ -14,14 +14,14 @@
 #' @template ret_smoof_single
 #' @export
 makeRosenbrockFunction = function(dimensions) {
-  assertCount(dimensions)
+  assertInt(dimensions, lower = 2)
   force(dimensions)
   makeSingleObjectiveFunction(
     name = paste(dimensions, "-d Rosenbrock Function", sep = ""),
     id = paste0("rosenbrock_", dimensions, "d"),
     fn = function(x) {
       assertNumeric(x, len = dimensions, any.missing = FALSE, all.missing = FALSE)
-      i = 1:(length(x) - 1L)
+      i = seq_len(length(x) - 1L)
       sum(100 * (x[i]^2 - x[i + 1])^2 + (x[i] - 1)^2)
     },
     par.set = makeNumericParamSet(

--- a/bbob_generate_images.R
+++ b/bbob_generate_images.R
@@ -5,11 +5,11 @@ load_all(".")
 
 fids = 1:24
 iid = 1L
-dimension = 2L
+dimensions = 2L
 
 # save the plot of each fn as 'bbob/{fn}.pdf'
 for (fid in fids) {
-  bbob.fn = makeBBOBFunction(dimension = dimension, fid = fid, iid = iid)
+  bbob.fn = makeBBOBFunction(dimensions = dimensions, fid = fid, iid = iid)
   file.name = paste("bbob/", getName(bbob.fn), "pdf", sep = ".")
   pdf(file.name)
   plot3D(bbob.fn, title = getName(bbob.fn))

--- a/inst/mpm2.py
+++ b/inst/mpm2.py
@@ -4,6 +4,12 @@ import random
 
 import numpy as np
 
+try:
+    # Python 2 forward compatibility
+    range = xrange
+except NameError:
+    pass
+
 class MultiplePeaksModel2:
     """A test problem
     """
@@ -26,8 +32,8 @@ class MultiplePeaksModel2:
             rotationMatrix = np.eye(numberVariables)
             if rotated:
                 quarterPi = math.pi / 4.0
-                for j in xrange(numberVariables - 1):
-                    for k in xrange(j + 1, numberVariables):
+                for j in range(numberVariables - 1):
+                    for k in range(j + 1, numberVariables):
                         r = np.eye(numberVariables)
                         alpha = runi(-quarterPi, quarterPi)
                         r[j,j] = cos(alpha)
@@ -164,10 +170,10 @@ class MultiplePeaksModel2:
             # determine random uniform cluster center
             clusterCenter = np.random.rand(numberVariables)
         peaks = []
-        for i in xrange(numberPeaks):
+        for i in range(numberPeaks):
             position = np.random.randn(numberVariables) / 6.0 * math.sqrt(numberVariables) + clusterCenter
             # repair box constraint violations of position
-            for j in xrange(numberVariables):
+            for j in range(numberVariables):
                 while position[j] < 0.0 or 1.0 < position[j]:
                     if 1.0 < position[j]:
                         position[j] = 1.0 - (position[j] - 1.0)
@@ -186,8 +192,8 @@ class MultiplePeaksModel2:
         numberRemainingPeaks = numberPeaks - numberGlobalOptima
         assert(numberRemainingPeaks >= 0)
         runi = random.uniform
-        peaks = [cls.Peak(numberVariables, 1.0, runi(*shapeRange), runi(*radiusRange), rotated=rotated, peakShape=peakShape) for _ in xrange(numberGlobalOptima)]
-        peaks.extend([cls.Peak(numberVariables, runi(*heightRange), runi(*shapeRange), runi(*radiusRange), rotated=rotated, peakShape=peakShape) for _ in xrange(numberRemainingPeaks)])
+        peaks = [cls.Peak(numberVariables, 1.0, runi(*shapeRange), runi(*radiusRange), rotated=rotated, peakShape=peakShape) for _ in range(numberGlobalOptima)]
+        peaks.extend([cls.Peak(numberVariables, runi(*heightRange), runi(*shapeRange), runi(*radiusRange), rotated=rotated, peakShape=peakShape) for _ in range(numberRemainingPeaks)])
         return peaks
 
 

--- a/man/addCountingWrapper.Rd
+++ b/man/addCountingWrapper.Rd
@@ -20,7 +20,7 @@ number of function evaluations of the wrapped function to compute the function
 values and finally passes down the argument to the wrapped \code{smoof_function}.
 }
 \examples{
-fn = makeBBOBFunction(dimension = 2L, fid = 1L, iid = 1L)
+fn = makeBBOBFunction(dimensions = 2L, fid = 1L, iid = 1L)
 fn = addCountingWrapper(fn)
 
 # we get a value of 0 since the function has not been called yet

--- a/man/addLoggingWrapper.Rd
+++ b/man/addLoggingWrapper.Rd
@@ -32,7 +32,7 @@ down the evaluation of the function.
 }
 \examples{
 # We first build the smoof function and apply the logging wrapper to it
-fn = makeSphereFunction(dimension = 2L)
+fn = makeSphereFunction(dimensions = 2L)
 fn = addLoggingWrapper(fn, logg.x = TRUE)
 
 # We now apply an optimization algorithm to it and the logging wrapper keeps

--- a/man/makeBBOBFunction.Rd
+++ b/man/makeBBOBFunction.Rd
@@ -5,10 +5,10 @@
 \title{Generator for the noiseless function set of the real-parameter Black-Box
 Optimization Benchmarking (BBOB).}
 \usage{
-makeBBOBFunction(dimension, fid, iid)
+makeBBOBFunction(dimensions, fid, iid)
 }
 \arguments{
-\item{dimension}{[\code{integer(1)}]\cr
+\item{dimensions}{[\code{integer(1)}]\cr
 Problem dimension. Integer value between 2 and 40.}
 
 \item{fid}{[\code{integer(1)}]\cr
@@ -30,7 +30,7 @@ each column consists of one parameter setting.
 }
 \examples{
 # get the first instance of the 2D Sphere function
-fn = makeBBOBFunction(dimension = 2L, fid = 1L, iid = 1L)
+fn = makeBBOBFunction(dimensions = 2L, fid = 1L, iid = 1L)
 if (require(plot3D)) {
   plot3D(fn, contour = TRUE)
 }

--- a/man/makeBiObjBBOBFunction.Rd
+++ b/man/makeBiObjBBOBFunction.Rd
@@ -5,11 +5,11 @@
 \title{Generator for the function set of the real-parameter Bi-Objective
 Black-Box Optimization Benchmarking (BBOB).}
 \usage{
-makeBiObjBBOBFunction(dimension, fid, iid)
+makeBiObjBBOBFunction(dimensions, fid, iid)
 }
 \arguments{
-\item{dimension}{[\code{integer(1)}]\cr
-Problem dimension. Integer value between 2 and 40.}
+\item{dimensions}{[\code{integer(1)}]\cr
+Problem dimensions. Integer value between 2 and 40.}
 
 \item{fid}{[\code{integer(1)}]\cr
 Function identifier. Integer value between 1 and 55.}
@@ -31,11 +31,11 @@ a bi-objective problem.
 \examples{
 # get the fifth instance of the concatenation of the
 # 3D versions of sphere and Rosenbrock
-fn = makeBiObjBBOBFunction(dimension = 3L, fid = 4L, iid = 5L)
+fn = makeBiObjBBOBFunction(dimensions = 3L, fid = 4L, iid = 5L)
 fn(c(3, -1, 0))
 # compare to the output of its single-objective pendants
-f1 = makeBBOBFunction(dimension = 3L, fid = 1L, iid = 2L * 5L + 1L)
-f2 = makeBBOBFunction(dimension = 3L, fid = 8L, iid = 2L * 5L + 2L)
+f1 = makeBBOBFunction(dimensions = 3L, fid = 1L, iid = 2L * 5L + 1L)
+f2 = makeBBOBFunction(dimensions = 3L, fid = 8L, iid = 2L * 5L + 2L)
 identical(fn(c(3, -1, 0)), c(f1(c(3, -1, 0)), f2(c(3, -1, 0))))
 }
 \references{

--- a/man/makeMultiObjectiveFunction.Rd
+++ b/man/makeMultiObjectiveFunction.Rd
@@ -4,10 +4,11 @@
 \alias{makeMultiObjectiveFunction}
 \title{Generator for multi-objective target functions.}
 \usage{
-makeMultiObjectiveFunction(name = NULL, id = NULL, description = NULL, fn,
-  has.simple.signature = TRUE, par.set, n.objectives = NULL,
-  noisy = FALSE, fn.mean = NULL, minimize = NULL, vectorized = FALSE,
-  constraint.fn = NULL, ref.point = NULL)
+makeMultiObjectiveFunction(name = NULL, id = NULL,
+  description = NULL, fn, has.simple.signature = TRUE, par.set,
+  n.objectives = NULL, noisy = FALSE, fn.mean = NULL,
+  minimize = NULL, vectorized = FALSE, constraint.fn = NULL,
+  ref.point = NULL)
 }
 \arguments{
 \item{name}{[\code{character(1)}]\cr

--- a/man/makeSingleObjectiveFunction.Rd
+++ b/man/makeSingleObjectiveFunction.Rd
@@ -4,10 +4,11 @@
 \alias{makeSingleObjectiveFunction}
 \title{Generator for single-objective target functions.}
 \usage{
-makeSingleObjectiveFunction(name = NULL, id = NULL, description = NULL,
-  fn, has.simple.signature = TRUE, vectorized = FALSE, par.set,
-  noisy = FALSE, fn.mean = NULL, minimize = TRUE, constraint.fn = NULL,
-  tags = character(0), global.opt.params = NULL, global.opt.value = NULL,
+makeSingleObjectiveFunction(name = NULL, id = NULL,
+  description = NULL, fn, has.simple.signature = TRUE,
+  vectorized = FALSE, par.set, noisy = FALSE, fn.mean = NULL,
+  minimize = TRUE, constraint.fn = NULL, tags = character(0),
+  global.opt.params = NULL, global.opt.value = NULL,
   local.opt.params = NULL, local.opt.values = NULL)
 }
 \arguments{

--- a/man/mnof.Rd
+++ b/man/mnof.Rd
@@ -5,10 +5,10 @@
 \title{Helper function to create numeric multi-objective optimization test function.}
 \usage{
 mnof(name = NULL, id = NULL, par.len = NULL, par.id = "x",
-  par.lower = NULL, par.upper = NULL, n.objectives, description = NULL,
-  fn, vectorized = FALSE, noisy = FALSE, fn.mean = NULL,
-  minimize = rep(TRUE, n.objectives), constraint.fn = NULL,
-  ref.point = NULL)
+  par.lower = NULL, par.upper = NULL, n.objectives,
+  description = NULL, fn, vectorized = FALSE, noisy = FALSE,
+  fn.mean = NULL, minimize = rep(TRUE, n.objectives),
+  constraint.fn = NULL, ref.point = NULL)
 }
 \arguments{
 \item{name}{[\code{character(1)}]\cr

--- a/man/plot2DNumeric.Rd
+++ b/man/plot2DNumeric.Rd
@@ -5,7 +5,8 @@
 \title{Plot a two-dimensional numeric function.}
 \usage{
 plot2DNumeric(x, show.optimum = FALSE, main = getName(x),
-  render.levels = FALSE, render.contours = TRUE, n.samples = 100L, ...)
+  render.levels = FALSE, render.contours = TRUE, n.samples = 100L,
+  ...)
 }
 \arguments{
 \item{x}{[\code{smoof_function}]\cr

--- a/man/snof.Rd
+++ b/man/snof.Rd
@@ -6,10 +6,10 @@
 \usage{
 snof(name = NULL, id = NULL, par.len = NULL, par.id = "x",
   par.lower = NULL, par.upper = NULL, description = NULL, fn,
-  vectorized = FALSE, noisy = FALSE, fn.mean = NULL, minimize = TRUE,
-  constraint.fn = NULL, tags = character(0), global.opt.params = NULL,
-  global.opt.value = NULL, local.opt.params = NULL,
-  local.opt.values = NULL)
+  vectorized = FALSE, noisy = FALSE, fn.mean = NULL,
+  minimize = TRUE, constraint.fn = NULL, tags = character(0),
+  global.opt.params = NULL, global.opt.value = NULL,
+  local.opt.params = NULL, local.opt.values = NULL)
 }
 \arguments{
 \item{name}{[\code{character(1)}]\cr

--- a/tests/testthat/test_counting_evaluations.R
+++ b/tests/testthat/test_counting_evaluations.R
@@ -1,7 +1,7 @@
 context("counting evaluations")
 
 test_that("countingWrapper counts correctly", {
-  fn = makeBBOBFunction(fid = 1L, iid = 1L, dimension = 8L)
+  fn = makeBBOBFunction(fid = 1L, iid = 1L, dimensions = 8L)
   expect_false(doesCountEvaluations(fn))
   fn = addCountingWrapper(fn)
   expect_true(doesCountEvaluations(fn))

--- a/tests/testthat/test_logging.R
+++ b/tests/testthat/test_logging.R
@@ -8,7 +8,7 @@ expect_logging_result_structure = function(x) {
 }
 
 test_that("logging for functions with matrix input works well", {
-  fn = makeBBOBFunction(fid = 1L, iid = 1L, dimension = 10L)
+  fn = makeBBOBFunction(fid = 1L, iid = 1L, dimensions = 10L)
   fn = addLoggingWrapper(fn, logg.x = TRUE)
   fn(matrix(runif(10L * 10L), ncol = 10L))
 
@@ -20,15 +20,15 @@ test_that("logging for functions with matrix input works well", {
 
 test_that("logging for simple functions works well", {
   # generate Sphere function
-  for (dimension in c(1L, 2L, 5L, 10L)) {
-    fn = makeSphereFunction(dimension = dimension)
+  for (dimensions in c(1L, 2L, 5L, 10L)) {
+    fn = makeSphereFunction(dimensions = dimensions)
     par.ids = getParamIds(getParamSet(fn), with.nr = TRUE, repeated = TRUE)
 
     # add logger for both x and y values
     fn = addLoggingWrapper(fn, logg.x = TRUE)
 
     # now apply some evaluations
-    fn(runif(dimension))
+    fn(runif(dimensions))
 
     # check for logged vals
     res = getLoggedValues(fn)
@@ -38,7 +38,7 @@ test_that("logging for simple functions works well", {
     expect_equal(length(res$obj.vals), 1L)
 
     for (i in seq(10L)) {
-      fn(runif(dimension))
+      fn(runif(dimensions))
     }
     res = getLoggedValues(fn)
 
@@ -50,7 +50,7 @@ test_that("logging for simple functions works well", {
     res = getLoggedValues(fn, compact = TRUE)
     expect_true(is.data.frame(res))
     expect_equal(nrow(res), 11L)
-    expect_equal(ncol(res), dimension + 1L) # dim plus the single objective value
+    expect_equal(ncol(res), dimensions + 1L) # dim plus the single objective value
   }
 })
 

--- a/tests/testthat/test_soofuns.R
+++ b/tests/testthat/test_soofuns.R
@@ -50,7 +50,7 @@ test_that("BBOB functions work", {
     for (iid in iids) {
       for (dimension in dimensions) {
         generator = sprintf("(FID: %i, IID : %i, DIM: %i)", fid, iid, dimension)
-        bbob.fn = makeBBOBFunction(dimension = dimension, fid = fid, iid = iid)
+        bbob.fn = makeBBOBFunction(dimensions = dimension, fid = fid, iid = iid)
         # check vectorized input and output
         if (isVectorized(bbob.fn)) {
           par1 = rep(1, dimension)
@@ -91,7 +91,7 @@ test_that("CEC 2009 functions work", {
   dimensions = c(3, 5, 10)
   for (id in ids) {
     for (dimension in dimensions) {
-      fn = makeUFFunction(dimension = dimension, id = id)
+      fn = makeUFFunction(dimensions = dimension, id = id)
       param = sampleValue(getParamSet(fn))
       value = fn(param)
       expect_true(is.numeric(value))

--- a/tests/testthat/test_soofuns.R
+++ b/tests/testthat/test_soofuns.R
@@ -20,7 +20,13 @@ test_that("single-objective test function generators work", {
             fun = try(do.call(fun.generator, list(dimensions = 2L)), silent = TRUE)
         }
         if (inherits(fun, "try-error")) {
-            fun = do.call(fun.generator, list(dimensions = 3L, n.objectives = 2L))
+            fun = try(do.call(fun.generator, list(dimensions = 3L, n.objectives = 2L)), silent = TRUE)
+        }
+        if (inherits(fun, "try-error")) {
+            fun = try(do.call(fun.generator, list(dimensions = 3L, fid = 2L, iid = 1L)), silent = TRUE) #BBOBFunction
+        }
+        if (inherits(fun, "try-error")) {
+            fun = try(do.call(fun.generator, list(n.objectives = 2L, k = 2L, l = 2L))) #WFG
         }
         expectIsSmoofFunction(fun, attr(fun.generator, "name"))
         if (hasGlobalOptimum(fun)) {


### PR DESCRIPTION
- Rosenbrock has to have at leas d = 2
- MultiplePeaksModel2 (mpm2.py) should now also work with python3
- All function generators have now `dimensions` argument as it was more common than the singular `dimension`. This is a compatible change thanks to partial argument matching.
- Fix tests
- use geom_raster instead of geom_grid (#119)