### PR TITLE
allow int/num 2d plot

### DIFF
--- a/R/plot.autoplot.R
+++ b/R/plot.autoplot.R
@@ -105,7 +105,7 @@ autoplot.smoof_function = function(x,
   n.pars = length(par.names)
 
   # determine IDs of numeric and factor-like parameters
-  numeric.idx = which(par.types == "numeric")
+  numeric.idx = which(par.types %in% c("numeric", "integer"))
   discrete.idx = which(par.types %in% c("factor", "logical"))
 
   # how many numeric/discrete parameters do exist?

--- a/R/plot.helpers.R
+++ b/R/plot.helpers.R
@@ -97,6 +97,12 @@ generateDataframeForGGPlot2 = function(fun, length.out = 50L) {
       values = lapply(1:the.par$len, function(i) {
         unlist(the.par$values, use.names = FALSE)
       })
+    } else if (par.type == "integer") {
+      values = unique(round(seq(the.par$lower, the.par$upper, length.out = length.out)))
+    } else if (par.type == "integervector") {
+      values = lapply(1:the.par$len, function(i) {
+        unique(round(seq(the.par$lower[i], the.par$upper[i], length.out = length.out)))
+      })
     } else if (par.type == "logical") {
       values = as.character(unlist(the.par$values, use.names = FALSE))
     } else if (par.type == "logicalvector") {

--- a/tests/testthat/test_plotting.R
+++ b/tests/testthat/test_plotting.R
@@ -14,7 +14,7 @@ test_that("autoplot functions for 1D numeric functions works as expected", {
   plot(fn, show.optimum = TRUE, n.samples = 50L)
   checkGGPlot(pl, title = "Test function", "x", "y")
 
-  pl = autoplot(autoplot(object, ...))
+  pl = autoplot(fn, show.optimum = TRUE, n.samples = 50L)
   checkGGPlot(pl, title = "Test function", "x", "y")
 
   # Now check for wrapped functions

--- a/tests/testthat/test_plotting.R
+++ b/tests/testthat/test_plotting.R
@@ -14,7 +14,7 @@ test_that("autoplot functions for 1D numeric functions works as expected", {
   plot(fn, show.optimum = TRUE, n.samples = 50L)
   checkGGPlot(pl, title = "Test function", "x", "y")
 
-  pl = autoplot(fn, show.optimum = TRUE, n.samples = 50L)
+  pl = autoplot(autoplot(object, ...))
   checkGGPlot(pl, title = "Test function", "x", "y")
 
   # Now check for wrapped functions
@@ -129,6 +129,19 @@ test_that("autoplot functions for mixed functions (discrete/logical and numeric 
   pl = autoplot(fn)
   checkGGPlot(pl, title = getName(fn), "x1", "x2")
   checkGGFacets(pl, c("disc1", "logic"))
+
+  fn = makeSingleObjectiveFunction(
+    name = "1d Real + 1d Int",
+    fn = function(x) {
+      x$x1 + x$x2
+    },
+    has.simple.signature = FALSE,
+    par.set = makeParamSet(
+      makeNumericParam("x1", lower = -5, upper = 5),
+      makeIntegerParam("x2", lower = -3, upper = 3)
+    )
+  )
+  pf = autoplot(fn)
 
 })
 


### PR DESCRIPTION
Previously it was not possible to mix real and integer values to obtain a 2d plot in autoplot.
This PR should fix this issue.