### PR TITLE
Fix name of Powell-Sum generator

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,8 +5,8 @@ Description: Provides generators for a high number of both single- and multi-
     objective test functions which are frequently used for the benchmarking of
     (numerical) optimization algorithms. Moreover, it offers a set of convenient
     functions to generate, plot and work with objective functions.
-Version: 1.6.0.3
-Date: 2020-04-01
+Version: 1.6.0.4
+Date: 2021-04-29
 Authors@R: c(person("Jakob", "Bossek", email = "j.bossek@gmail.com", role =
     c("aut", "cre")), person("Pascal", "Kerschke", email = "kerschke@uni-muenster.de",
     role = "ctb"))
@@ -32,5 +32,5 @@ Suggests:
 LazyData: yes
 ByteCompile: yes
 LinkingTo: Rcpp, RcppArmadillo
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Encoding: UTF-8

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,5 @@
-smoof 1.6.3
-===========
+smoof 1.6.0.3
+=============
 
 * Added MMF1 to MMF13 problems from CEC2019 test suite
 * Added SYM-Part simple, SYM-Part rotated and Omni-Test problems from CEC2019 test suite

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# smoof 1.6.3
+# smoof 1.6.0.3
 
 ## New features
 

--- a/R/sof.powell.sum.R
+++ b/R/sof.powell.sum.R
@@ -36,6 +36,6 @@ makePowellSumFunction = function(dimensions) {
 }
 
 class(makePowellSumFunction) = c("function", "smoof_generator")
-attr(makePowellSumFunction, "name") = c("Double-Sum")
+attr(makePowellSumFunction, "name") = c("Powell-Sum")
 attr(makePowellSumFunction, "type") = c("single-objective")
 attr(makePowellSumFunction, "tags") = c("single-objective", "continuous", "differentiable", "separable", "scalable", "unimodal")

--- a/tests/testthat/test_filterFunctionByTags.R
+++ b/tests/testthat/test_filterFunctionByTags.R
@@ -1,5 +1,10 @@
 context("function filtering works well")
 
+test_that("filterFunctionByTags returns unique names", {
+  fns = filterFunctionsByTags("single-objective") 
+  expect_false(any(duplicated(fns)))
+})
+
 test_that("filterFunctionByTags returns reasonable results", {
   expected_tags = c("multimodal", "scalable")
   # check if function works well


### PR DESCRIPTION
The name of `makePowellSumFunction` is "Double-Sum" but should be "Powell-Sum". Otherwise `filterFunctionsByTags` returns duplicate names. The patch also adds a test to check that all names returned by `filterFunctionsByTags("single-objective")` are unique.