### PR TITLE
Small fixes for function ids

### DIFF
--- a/R/getID.R
+++ b/R/getID.R
@@ -1,7 +1,7 @@
-#' Return the ID / short name of the function.
+#' Return the ID / short name of the function or \code{NA} if no ID is set.
 #'
 #' @template arg_smoof_function
-#' @return [\code{character(1)}]
+#' @return [\code{character(1)}] or \code{NA}
 #' @export
 getID = function(fn) {
   UseMethod("getID")

--- a/R/makeBBOBFunction.R
+++ b/R/makeBBOBFunction.R
@@ -46,6 +46,7 @@ makeBBOBFunction = function(dimensions, fid, iid) {
 
   makeSingleObjectiveFunction(
     name = sprintf("BBOB_%i_%i_%i", dimensions, fid, iid),
+    id = sprintf("bbob_%i_%i_%i", dimensions, fid, iid),
     description = sprintf("%i-th noiseless BBOB function\n(FID: %i, IID: %i, DIMENSION: %i)",
       fid, fid, iid, dimensions),
     fn = function(x) {

--- a/R/makeObjectiveFunction.R
+++ b/R/makeObjectiveFunction.R
@@ -99,7 +99,7 @@ makeObjectiveFunction = function(
   structure(
     fn,
     name = coalesce(name, ""),
-    id = coalesce(id, NA),
+    id = coalesce(id, as.character(NA)),
     description = coalesce(description, ""),
     par.set = par.set,
     noisy = noisy,


### PR DESCRIPTION
We use the function ID to generate filenames and short labels in our experiments and I noticed that the BBOB functions are missing IDs. This PR adds IDs for them. It also documents that IDs returned by `getID()` can be missing (`NA`) and ensures that `is.character(getID(fun))` is true even when `getID` returns `NA`.