### PR TITLE
Add vectorization for MPM2 functions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,7 @@ smoof 1.6.0.3
 * getLoggedValues now correctly names function parameters.
 * BBOB test function now return an ID.
 * Changed: moved from rPython and RJSONIO to reticulate.
+* Added vectorization to the MPM2 generator
 
 smoof 1.6.0
 ===========

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * getLoggedValues now correctly names function parameters.
 * BBOB test function now return an ID.
 * Changed: moved from rPython and RJSONIO to reticulate
+* Added vectorization to the MPM2 generator
 
 ## Bugfixes
 

--- a/R/sof.mpm2.R
+++ b/R/sof.mpm2.R
@@ -83,10 +83,10 @@ makeMPM2Function = function(n.peaks, dimensions, topology, seed, rotated = TRUE,
     description = sprintf("Funnel-like function\n(n.peaks: %i, dimension: %i, topology: %s, seed: %i, rotated: %s, shape: %s)",
       n.peaks, dimensions, topology, seed, rotated, peak.shape),
     fn = function(x) {
-      assertNumeric(x, len = dimensions, any.missing = FALSE, all.missing = FALSE)
-      evaluateProblem(as.double(x), n.peaks, dimensions, topology, seed, rotated, peak.shape)
+      evaluateProblem(x, n.peaks, dimensions, topology, seed, rotated, peak.shape)
     },
     par.set = par.set,
+    vectorized = TRUE,
     tags = c("non-separable", "scalable", "continuous", "multimodal"),
     local.opt.params = local.opt.params,
     global.opt.params = global.opt.params

--- a/inst/mpm2.py
+++ b/inst/mpm2.py
@@ -313,7 +313,12 @@ def initProblem(npeaks, dimension, topology, randomSeed, rotated, peakShape):
 def evaluateProblem(position, npeaks, dimension, topology, randomSeed, rotated, peakShape):
     global currentProblem
     initProblem(npeaks, dimension, topology, randomSeed, rotated, peakShape)
-    return currentProblem.objectiveFunction(position)
+    
+    if isinstance(position, np.ndarray):
+      # if we have a matrix input, apply the function for each column
+      return [currentProblem.objectiveFunction(col) for col in position.T]
+    else:
+      return currentProblem.objectiveFunction(position)
 
 def getLocalOptimaParams(npeaks, dimension, topology, randomSeed, rotated, peakShape):
     global currentProblem


### PR DESCRIPTION
I added vectorization to the MPM2 interface, which produces significant speed-ups when evaluating a large amount of points, e.g., for visualization purposes.

On my machine, this results in a speed-up of about 2e-4 seconds per evaluation:

```r
library(smoof)

fn <- makeMPM2Function(
  n.peaks = 3L,
  dimensions = 2L,
  topology = "random",
  seed = 4L,
  rotated = TRUE,
  peak.shape = "ellipse"
)

dec_space <- matrix(runif(2 * 1e5), ncol = 2)

system.time(fn(t(dec_space)))
#>   user  system elapsed 
#>  5.037   0.076   5.478 

system.time(apply(dec_space, 1, fn))
#>   user  system elapsed 
#> 24.399   0.344  25.722 
```

Let me know if you need anything else before we can integrate this change :-)