### PR TITLE
Faster evaluation for MPM2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,13 @@ Authors@R: c(
     family = "Kerschke",
     email = "pascal.kerschke@tu-dresden.de",
     role = "ctb",
-    comment = c(ORCID = "0000-0003-2862-1418")))
+    comment = c(ORCID = "0000-0003-2862-1418")),
+  person(
+    given = "Lennart",
+    family = "Schäpermeier",
+    email = "lennart.schaepermeier@tu-dresden.de",
+    role = "ctb",
+    comment = c(ORCID = "0000-0003-3929-7465")))
 Maintainer: Jakob Bossek <j.bossek@gmail.com>
 URL: https://jakobbossek.github.io/smoof/, https://github.com/jakobbossek/smoof
 BugReports: https://github.com/jakobbossek/smoof/issues

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@ smoof 1.6.0.4
 
 * Fixed bug in getLoggedValues when logging of x-values was set to FALSE in addLoggingWrapper
 * Fixed bug with instance ID mapping in makeBiObjBBOBFunction
+* Added extra helper functions to extract all problem instance-specific data from MPM2 generator
 
 smoof 1.6.0.3
 =============

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,7 @@ smoof 1.6.0.4
 * Fixed bug in getLoggedValues when logging of x-values was set to FALSE in addLoggingWrapper
 * Fixed bug with instance ID mapping in makeBiObjBBOBFunction
 * Added extra helper functions to extract all problem instance-specific data from MPM2 generator
+* Added R-based evaluation environment for MPM2 generator which greatly accelerates evaluation in multi-objective settings
 
 smoof 1.6.0.3
 =============

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # smoof 1.6.0.4
 
+## New features
+
+* Added extra helper functions to extract all problem instance-specific data from MPM2 generator
+
 ## Bugfixes 
 
 * Fixed bug in getLoggedValues when logging of x-values was set to FALSE in addLoggingWrapper

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## New features
 
 * Added extra helper functions to extract all problem instance-specific data from MPM2 generator
+* Added R-based evaluation environment for MPM2 generator which greatly accelerates evaluation in multi-objective settings
 
 ## Bugfixes 
 

--- a/R/sof.mpm2.R
+++ b/R/sof.mpm2.R
@@ -13,11 +13,11 @@
 #' @param peak.shape [\code{character(1)}]\cr
 #'   Shape of peak(s). Possible values are \dQuote{ellipse} and \dQuote{sphere}.
 #' @param evaluation.env [\code{character(1)}]\cr
-#'   Evaluation environment after the function was created. Possible values are
-#'   \dQuote{R} (default) and \dQuote{Python}. The original generation of the
-#'   problem is always done in the original Python environment. However,
-#'   evaluation in R is faster, especially if multiple MPM2 functions are used
-#'   in a multi-objective setting.
+#'   Evaluation environment after the function was created. Possible
+#'   (case-insensitive) values are \dQuote{R} (default) and \dQuote{Python}. The
+#'   original generation of the problem is always done in the original Python
+#'   environment. However, evaluation in R is faster, especially if multiple
+#'   MPM2 functions are used in a multi-objective setting.
 #' @return [\code{smoof_single_objective_function}]
 #' @examples
 #' \dontrun{
@@ -87,11 +87,11 @@ makeMPM2Function = function(n.peaks, dimensions, topology, seed, rotated = TRUE,
   global.opt.params = eval(getGlobalOptimaParams(n.peaks, dimensions, topology, seed, rotated, peak.shape), envir = .GlobalEnv)
   global.opt.params = matrix(global.opt.params[[1L]], nrow = 1L)
 
-  if (evaluation.env == "Python") {
+  if (tolower(evaluation.env) == "python") {
     evalFn = function(x) {
       evaluateProblem(x, n.peaks, dimensions, topology, seed, rotated, peak.shape)
     }
-  } else if (evaluation.env == "R") {
+  } else if (tolower(evaluation.env) == "r") {
     # helper functions
     getPeakMetadata = function(n.peaks, dimensions, topology, seed, rotated, peak.shape) {
       

--- a/R/sof.mpm2.R
+++ b/R/sof.mpm2.R
@@ -128,12 +128,7 @@ makeMPM2Function = function(n.peaks, dimensions, topology, seed, rotated = TRUE,
     
     createPeakFunction = function(cov, xopt, height, shape, radius) {
       function(x) {
-        if (is.matrix(x)) {
-          dx = t(apply(x, 1, function(row) (row - xopt))) %*% chol(cov)
-          md = apply(dx, 1, function(row) sqrt(sum(row**2)))
-        } else {
-          md = sqrt(t(x - xopt) %*% cov %*% (x - xopt))
-        }
+        md = sqrt(t(x - xopt) %*% cov %*% (x - xopt))
         g = height / (1 + md**shape / radius)
         return(1 - g)
       }

--- a/inst/mpm2.py
+++ b/inst/mpm2.py
@@ -280,6 +280,19 @@ class MultiplePeaksModel2:
             X = X.reshape(len(X) * len(X[0]))
             res.append(np.matrix(X).tolist())
         return res
+      
+    def getAllPeaks(self):
+        return np.vstack(self.peaks)
+      
+    def getAllHeights(self):
+        return [peak.height for peak in self.peaks]
+      
+    def getAllShapes(self):
+        return [peak.shape for peak in self.peaks]
+      
+    def getAllRadii(self):
+        return [peak.radius for peak in self.peaks]
+
 
 
 
@@ -334,6 +347,26 @@ def getCovarianceMatrices(npeaks, dimension, topology, randomSeed, rotated, peak
     global currentProblem
     initProblem(npeaks, dimension, topology, randomSeed, rotated, peakShape)
     return currentProblem.getCovMatrices()
+
+def getAllPeaks(npeaks, dimension, topology, randomSeed, rotated, peakShape):
+    global currentProblem
+    initProblem(npeaks, dimension, topology, randomSeed, rotated, peakShape)
+    return currentProblem.getAllPeaks()
+
+def getAllHeights(npeaks, dimension, topology, randomSeed, rotated, peakShape):
+    global currentProblem
+    initProblem(npeaks, dimension, topology, randomSeed, rotated, peakShape)
+    return currentProblem.getAllHeights()
+
+def getAllShapes(npeaks, dimension, topology, randomSeed, rotated, peakShape):
+    global currentProblem
+    initProblem(npeaks, dimension, topology, randomSeed, rotated, peakShape)
+    return currentProblem.getAllShapes()
+
+def getAllRadii(npeaks, dimension, topology, randomSeed, rotated, peakShape):
+    global currentProblem
+    initProblem(npeaks, dimension, topology, randomSeed, rotated, peakShape)
+    return currentProblem.getAllRadii()
 
 if __name__ == "__main__":
     # nothing to do here

--- a/man/makeMPM2Function.Rd
+++ b/man/makeMPM2Function.Rd
@@ -10,7 +10,8 @@ makeMPM2Function(
   topology,
   seed,
   rotated = TRUE,
-  peak.shape = "ellipse"
+  peak.shape = "ellipse",
+  evaluation.env = "R"
 )
 }
 \arguments{
@@ -32,6 +33,13 @@ of elliptically shaped peaks.}
 
 \item{peak.shape}{[\code{character(1)}]\cr
 Shape of peak(s). Possible values are \dQuote{ellipse} and \dQuote{sphere}.}
+
+\item{evaluation.env}{[\code{character(1)}]\cr
+Evaluation environment after the function was created. Possible values are
+\dQuote{R} (default) and \dQuote{Python}. The original generation of the
+problem is always done in the original Python environment. However,
+evaluation in R is faster, especially if multiple MPM2 functions are used
+in a multi-objective setting.}
 }
 \value{
 [\code{smoof_single_objective_function}]

--- a/tests/testthat/test_soofuns.R
+++ b/tests/testthat/test_soofuns.R
@@ -74,10 +74,42 @@ test_that("Multiple peaks model 2 (MPM2) functions work", {
         for (topology in c("funnel", "random")) {
           for (rotated in c(TRUE, FALSE)) {
             for (peak.shape in c("ellipse", "sphere")) {
-              fn = makeMPM2Function(n.peaks = n.peaks, dimension = dimension, topology = topology, seed = 123, rotated = rotated, peak.shape = peak.shape)
-              expect_is(fn, "smoof_single_objective_function")
-              y = fn(rep(0.1, dimension))
-              expect_true(is.numeric(y))
+              fnp = makeMPM2Function(n.peaks = n.peaks, dimensions = dimension,
+                                     topology = topology, seed = 123, rotated = rotated,
+                                     peak.shape = peak.shape, evaluation.env = "Python")
+              fnr = makeMPM2Function(n.peaks = n.peaks, dimensions = dimension,
+                                     topology = topology, seed = 123, rotated = rotated,
+                                     peak.shape = peak.shape, evaluation.env = "R")
+              
+              # confirm that both evaluation environments can be created
+              expect_is(fnp, "smoof_single_objective_function")
+              yp = fnp(rep(0.1, dimension))
+              expect_true(is.numeric(yp))
+              
+              expect_is(fnr, "smoof_single_objective_function")
+              yr = fnr(rep(0.1, dimension))
+              expect_true(is.numeric(yr))
+              
+              # confirm that results are identical between evaluation environments
+              expect_identical(yp, yr)
+              
+              # confirm vectorization works as expected
+              expect_true(isVectorized(fnr))
+              expect_true(isVectorized(fnp))
+              
+              par1 = rep(0.1, dimension)
+              par2 = rep(0.2, dimension)
+              
+              res.seq = c(fnr(par1), fnr(par2))
+              res.vec = fnr(cbind(par1, par2))
+              expect_true(all(res.seq == res.vec),
+                          info = sprintf("Sequential and vectorized input not equal for %s (R)", getID(fnr)))
+              
+              res.seq = c(fnr(par1), fnr(par2))
+              res.vec = fnr(cbind(par1, par2))
+              expect_true(all(res.seq == res.vec),
+                          info = sprintf("Sequential and vectorized input not equal for %s (Python)", getID(fnr)))
+              
             }
           }
         }


### PR DESCRIPTION
This PR adds support for extracting all instance-specific information for MPM2 problems from the original Python environment, and subsequently evaluating the problems within R instead of Python. This behavior is controlled by an additional parameter `evaluation.env`, which per default is set to the faster R.
It can be significantly faster in multi-objective optimization settings as the Python interface always only stores the configuration of the latest MPM2 function called, leading to expensive reconfigurations for each batch of evaluations.
Even in single-objective settings it is somewhat faster (about 20% for me).

In multi-objective settings it can easily be orders of magnitude faster when the MPM2 instance generation algorithm takes comparatively long to configure the problem. For example, on my machine:

```r
> env = "Python"
> 
> fn1 = makeMPM2Function(16, 2, "random", 8, evaluation.env = env)
> fn2 = makeMPM2Function(16, 2, "random", 9, evaluation.env = env)
> 
> system.time({
+   sapply(1:1e2, function(i) {
+     fn1(c(0.5, 0.5))
+     fn2(c(0.5, 0.5))
+   })
+ })
   user  system elapsed 
  1.239   0.002   0.613 
> library(smoof)
> 
> env = "R"
> 
> fn1 = makeMPM2Function(16, 2, "random", 8, evaluation.env = env)
> fn2 = makeMPM2Function(16, 2, "random", 9, evaluation.env = env)
> 
> system.time({
+   sapply(1:1e2, function(i) {
+     fn1(c(0.5, 0.5))
+     fn2(c(0.5, 0.5))
+   })
+ })
   user  system elapsed 
  0.018   0.000   0.011 
> 
```

Tests to check matching outputs are also provided. Let me know if you need me to change anything!

Cheers,
Lennart